### PR TITLE
Separation model from test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mrubyc-test (0.3.0)
+    mrubyc-test (0.4.0)
       activesupport (~> 5.2)
       rufo (~> 0.4)
       thor (~> 0.20)
@@ -33,7 +33,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rufo (0.6.0)
+    rufo (0.7.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mrubyc-test
 
-[![Build Status](https://travis-ci.com/hasumikin/mrubyc-test.svg?branch=master)](https://travis-ci.com/hasumikin/mrubyc-test)
+[![Build Status](https://travis-ci.com/mrubyc/mrubyc-test.svg?branch=master)](https://travis-ci.com/mrubyc/mrubyc-test)
 
 mrubyc-test is an unit test framework for [mruby/c](https://github.com/mrubyc/mrubyc), supporting basic assertions, stub and mock.
 

--- a/lib/mrubyc-test.rb
+++ b/lib/mrubyc-test.rb
@@ -63,8 +63,13 @@ module Mrubyc::Test
                puts cmd
                puts
                exit_code = system(cmd) ? 0 : 1
-               exit(exit_code) if exit_code > 0
-             end
+               if exit_code > 0
+                 print "\e[31m"
+                 puts "exit code: #{exit_code}"
+                 puts "\e[0m"
+                 exit(exit_code)
+               end
+            end
           end
         ensure
           FileUtils.rm hal_path

--- a/lib/mrubyc-test.rb
+++ b/lib/mrubyc-test.rb
@@ -57,6 +57,7 @@ module Mrubyc::Test
           Dir.chdir(tmp_dir) do
             [
              "RBENV_VERSION=#{mruby_version} mrbc -E -B test test.rb",
+             "RBENV_VERSION=#{mruby_version} mrbc -E -B models models.rb",
              "cc #{ENV["CFLAGS"]} #{ENV["LDFLAGS"]} -I #{pwd}/#{config['mrubyc_src_dir']} -o test main.c #{pwd}/#{config['mrubyc_src_dir']}/*.c #{pwd}/#{config['mrubyc_src_dir']}/hal/*.c",
              "./test"].each do |cmd|
                puts cmd

--- a/lib/mrubyc/test/generator/script.rb
+++ b/lib/mrubyc/test/generator/script.rb
@@ -10,9 +10,11 @@ module Mrubyc
         class << self
           def run(model_files: [], test_files:, test_cases:, verbose:, method_name_pattern:)
             config = Mrubyc::Test::Config.read
-            erb = ERB.new(File.read(File.expand_path('../../../../templates/test.rb.erb', __FILE__)), nil, '-')
+            test_erb = ERB.new(File.read(File.expand_path('../../../../templates/test.rb.erb', __FILE__)), nil, '-')
+            models_erb = ERB.new(File.read(File.expand_path('../../../../templates/models.rb.erb', __FILE__)), nil, '-')
             mrubyc_class_dir = File.expand_path('../../../../mrubyc-ext/', __FILE__)
-            File.write(File.join(config['test_tmp_dir'], 'test.rb'), Rufo.format(erb.result(binding)))
+            File.write(File.join(config['test_tmp_dir'], 'test.rb'), Rufo.format(test_erb.result(binding)))
+            File.write(File.join(config['test_tmp_dir'], 'models.rb'), Rufo.format(models_erb.result(binding)))
           end
         end
       end

--- a/lib/mrubyc/test/init.rb
+++ b/lib/mrubyc/test/init.rb
@@ -26,6 +26,8 @@ module Mrubyc
           puts "  write #{config['test_tmp_dir']}/.gitignore"
           File.open("#{config['test_tmp_dir']}/.gitignore", "w") do |f|
             f.puts "test"
+            f.puts "models.rb"
+            f.puts "models.c"
             f.puts "test.rb"
             f.puts "test.c"
           end

--- a/lib/mrubyc/test/version.rb
+++ b/lib/mrubyc/test/version.rb
@@ -1,5 +1,5 @@
 module Mrubyc
   module Test
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end

--- a/lib/templates/main.c.erb
+++ b/lib/templates/main.c.erb
@@ -1,6 +1,7 @@
 #include "mrubyc.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include "models.c"
 #include "test.c"
 
 #define MEMORY_SIZE (1024*64)-1
@@ -33,6 +34,7 @@ int main(void) {
   mrbc_init(my_memory_pool, MEMORY_SIZE);
   mrbc_define_method(0, mrbc_class_object, "debugprint", c_debugprint);
   mrbc_define_method(0, mrbc_class_object, "exit", c_exit);
+  mrbc_create_task( models, 0 );
   mrbc_create_task( test, 0 );
   mrbc_run();
   return exit_code;

--- a/lib/templates/models.rb.erb
+++ b/lib/templates/models.rb.erb
@@ -1,0 +1,3 @@
+<% model_files.each do |file_name| -%>
+  <%= File.read(file_name) %>
+<% end -%>

--- a/lib/templates/test.rb.erb
+++ b/lib/templates/test.rb.erb
@@ -14,6 +14,7 @@ if RUBY_VERSION == '1.9' && MRUBYC_VERSION
   end
   RUBY_DESCRIPTION = 'mruby/c ' + MRUBYC_VERSION
 else
+  require_relative "./models.rb"
   require 'objspace'
   def debugprint(message)
     puts
@@ -80,10 +81,6 @@ end
 
 <% %w(object hash mock mrubyc_test_case).each do |basename| -%>
   <%= File.read(File.join(mrubyc_class_dir, basename + '.rb')) %>
-<% end -%>
-
-<% model_files.each do |file_name| -%>
-  <%= File.read(file_name) %>
 <% end -%>
 
 <% test_files.each do |file_name| -%>


### PR DESCRIPTION
separate 'model task' from 'test task' to detect a mrubyc's bug that initializing a class which is defined in another task doesn't work