### PR TITLE
Amend CFLAGS option

### DIFF
--- a/lib/mrubyc-test.rb
+++ b/lib/mrubyc-test.rb
@@ -78,7 +78,7 @@ module Mrubyc::Test
       end
 
       def init_env
-        ENV["CFLAGS"] = "-std=gnu99 -DMRBC_DEBUG -DMRBC_USE_MATH=1 -Wall #{ENV["CFLAGS"]}"
+        ENV["CFLAGS"] = "-std=gnu99 -Wall #{ENV["CFLAGS"]}"
         ENV["LDFLAGS"] = "-Wl,--no-as-needed -lm #{ENV["LDFLAGS"]}"
       end
 

--- a/lib/mrubyc/test/version.rb
+++ b/lib/mrubyc/test/version.rb
@@ -1,5 +1,5 @@
 module Mrubyc
   module Test
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end


### PR DESCRIPTION
- get rid of MRBC_DEBUG (assuming `NDEBUG` in production build)
- eliminate MRBC_USE_MATH (and It will be added to mrubyc/.travis.yml)
- bump up minor version