### PR TITLE
fix default test_path

### DIFF
--- a/lib/mrubyc-test.rb
+++ b/lib/mrubyc-test.rb
@@ -112,7 +112,7 @@ module Mrubyc::Test
                eg: /home/hoge/mruby/build/host/bin/mrbc
                RBENV_VERSION will be ignored if you specify this option.
       DESC
-    def test(testfilepath = "test/*.rb")
+    def test(testfilepath = "")
       Mrubyc::Test::Init.init_main_c
       init_env
       config = Mrubyc::Test::Config.read


### PR DESCRIPTION
Fixed default test path to use test_dir in config.