### PR TITLE
Bump bundler to 2.4.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,4 +48,4 @@ DEPENDENCIES
   rspec (~> 3.9)
 
 BUNDLED WITH
-   2.2.5
+   2.4.6


### PR DESCRIPTION
Suppress deperecation warning

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

ref: https://github.com/rubygems/rubygems/issues/5234